### PR TITLE
link to C math library

### DIFF
--- a/dierckxSpline.go
+++ b/dierckxSpline.go
@@ -1,6 +1,7 @@
 package dierckx
 
 // #cgo FFLAGS: -fdefault-real-8
+// #cgo LDFLAGS: -lm
 // void splev (double*, int*, double*, int*, double*, double*, int*, int*);
 // void curfit (int*, int*, double*, double*, double*, double*, double*, int*, double*, int*, int*, double*, double*, double*, double*, int*, int*, int*);
 import "C"


### PR DESCRIPTION
Fixes the following issue on Centos 7:

```
/usr/bin/ld: $WORK/b039/_x003.o: undefined reference to symbol 'sqrt@@GLIBC_2.2.5'
//usr/lib64/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```